### PR TITLE
Implement content replacement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { useLoadBalancing } from './load-balancing';
 import { useUpstream } from './upstream';
 import { useCORS } from './cors';
 import { useRewrite } from './rewrite';
+import { useReplace } from './replace';
 
 import { WorkersKV } from './storage';
 import { createResponse, getHostname } from './utils';
@@ -41,6 +42,7 @@ export default function useProxy(
     useCORS,
     useRewrite,
     useUpstream,
+    useReplace,
   );
 
   const routes: Route[] = [];

--- a/src/replace.ts
+++ b/src/replace.ts
@@ -11,7 +11,7 @@ export const useReplace: Middleware = async (context, next) => {
   const path = new URL(request.url).pathname;
   const matches: ReplaceEntry[] = [];
   for (const patch of options.replace) {
-    if (patch.path === undefined || patch.path.test(path)) {
+    if (patch.replace.length > 0 && (patch.path === undefined || patch.path.test(path))) {
       patch.replace.forEach((entry) => {
         matches.push(entry);
       });
@@ -21,7 +21,7 @@ export const useReplace: Middleware = async (context, next) => {
   if (matches.length > 0) {
     let data = await response.text();
     matches.forEach(({ from, to }) => {
-      data = data.replace(from, to);
+      data = data.replaceAll(from, to);
     });
     context.response = new Response(data, response);
   }

--- a/src/replace.ts
+++ b/src/replace.ts
@@ -1,0 +1,30 @@
+import { Middleware } from '../types/middleware';
+import { ReplaceEntry } from '../types/replace';
+
+export const useReplace: Middleware = async (context, next) => {
+  const { request, response, options } = context;
+  if (options.replace === undefined) {
+    await next();
+    return;
+  }
+
+  const path = new URL(request.url).pathname;
+  const matches: ReplaceEntry[] = [];
+  for (const patch of options.replace) {
+    if (patch.path === undefined || patch.path.test(path)) {
+      patch.replace.forEach((entry) => {
+        matches.push(entry);
+      });
+    }
+  }
+
+  if (matches.length > 0) {
+    let data = await response.text();
+    matches.forEach(({ from, to }) => {
+      data = data.replace(from, to);
+    });
+    context.response = new Response(data, response);
+  }
+
+  await next();
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2020",
     "moduleResolution": "node",
     "lib": [
-      "ES2020",
+      "ES2021",
       "WebWorker"
     ],
     "types": [

--- a/types/proxy.ts
+++ b/types/proxy.ts
@@ -3,6 +3,7 @@ import { FirewallOptions } from './firewall';
 import { CORSOptions } from './cors';
 import { HeadersOptions } from './headers';
 import { RewriteOptions } from './rewrite';
+import { ReplaceOptions } from './replace';
 import { LoadBalancingOptions } from './load-balancing';
 
 export interface Options {
@@ -10,6 +11,7 @@ export interface Options {
   firewall?: FirewallOptions[];
   cors?: CORSOptions;
   rewrite?: RewriteOptions;
+  replace?: ReplaceOptions[];
   headers?: HeadersOptions;
   methods?: string[],
   loadBalancing?: LoadBalancingOptions,

--- a/types/replace.ts
+++ b/types/replace.ts
@@ -1,0 +1,9 @@
+export interface ReplaceEntry {
+  from: string | RegExp;
+  to: string;
+}
+
+export interface ReplaceOptions {
+  path?: RegExp;
+  replace: ReplaceEntry[];
+}


### PR DESCRIPTION
Enhanced `replace_dict`. Fixes #52

## Use Case (Not fully working though)
```js
import useProxy from "rocket-booster";

addEventListener("fetch", (event) => {
  const proxy = useProxy();
  proxy.use("/proxy/jsfiddle", {
    upstream: {
      domain: "jsfiddle.net",
      protocol: "https",
    },
    rewrite: {
      path: {
        "/proxy/jsfiddle/": "/",
      },
    },
    replace: [
      {
        path: /^\/[a-z0-9]+$/,
        replace: [
          { from: `"\/js`, to: `"/proxy/jsfiddle/js` },
          { from: `"\/css`, to: `"/proxy/jsfiddle/css` },
          {
            from: "fiddle.jshell.net",
            to: "your-domain/proxy/fiddle/jshell",
          },
          {
            from: "crbcdn.jsfiddle.net",
            to: "your-domain/proxy/fiddle/crbcdn",
          },
        ],
      },
    ],
  });
  proxy.use("/proxy/fiddle/crbcdn", {
    upstream: {
      domain: "crbcdn.jsfiddle.net",
      protocol: "https",
    },
    rewrite: {
      path: {
        "/proxy/fiddle/crbcdn/": "/",
      },
    },
  });
  proxy.use("/proxy/fiddle/jshell", {
    upstream: {
      domain: "fiddle.jshell.net",
      protocol: "https",
    },
    rewrite: {
      path: {
        "/proxy/fiddle/jshell/": "/",
      },
    },
  });
  const response = proxy.apply(event.request);
  event.respondWith(response);
});
```